### PR TITLE
chore: replace JamesIves/github-pages-deploy-action with official GitHub Pages action

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -26,8 +26,21 @@ jobs:
       - name: Build
         run: bun prod
 
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # v4.7.3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          branch: gh-pages
-          folder: __site
+          path: __site
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Replace JamesIves/github-pages-deploy-action with GitHub's official actions/deploy-pages
- Adopt artifact-based deployment approach by separating build and deploy jobs
- Align with GitHub Pages' new deployment method

## Changes
- `build` job: Build site and upload artifact using `actions/upload-pages-artifact`
- `deploy` job: Deploy to GitHub Pages using `actions/deploy-pages`
- Add required permissions (`pages: write`, `id-token: write`)
- Add GitHub Pages environment configuration

## Test plan
- [ ] GitHub Actions workflow runs successfully
- [ ] Deployment to GitHub Pages succeeds
- [ ] Deployed site displays correctly